### PR TITLE
use the file option

### DIFF
--- a/tasks/stss.js
+++ b/tasks/stss.js
@@ -44,6 +44,7 @@ module.exports = function(grunt) {
       src += options.punctuation;
       stss.renderSync({
         data: src,
+        file: f.src[0],
         includePaths: [path.join(process.cwd(), path.dirname(f.src))],
         success: function(tss) {
           grunt.file.write(f.dest, tss);


### PR DESCRIPTION
The `option.file` option in STSS may be of a great help to fix the way imported files are included / resolved, as shown in the PR RonaldTreur/STSS#28

This PR passes the option to stss, so that imports are resolved the right way.
